### PR TITLE
Add time period limiter using single sleep

### DIFF
--- a/limiter/src/lib.rs
+++ b/limiter/src/lib.rs
@@ -4,3 +4,4 @@ pub use limiter::Limiter;
 pub mod standard_sleep;
 pub mod time_period_standard_sleep;
 pub mod time_period_close_sleep;
+pub mod time_period_close_sleep_once;

--- a/limiter/src/time_period_close_sleep_once/mod.rs
+++ b/limiter/src/time_period_close_sleep_once/mod.rs
@@ -1,0 +1,93 @@
+use super::Limiter;
+
+pub struct LimiterImpl {
+    min_period: u32,
+    close_enough: std::time::Duration,
+}
+
+impl Default for LimiterImpl {
+    fn default() -> Self {
+        let mut result = LimiterImpl {
+            min_period: LimiterImpl::get_min_period(),
+            close_enough: std::time::Duration::from_micros(2),
+        };
+        result.init();
+        result
+    }
+}
+
+impl Drop for LimiterImpl {
+    fn drop(&mut self) {
+        self.shutdown()
+    }
+}
+
+impl LimiterImpl {
+    pub fn new() -> Self {
+        LimiterImpl::default()
+    }
+}
+
+impl Limiter for LimiterImpl {
+    fn wait(&self, time: std::time::Duration) {
+        let target_duration = time - self.close_enough;
+        let target_instant = std::time::Instant::now() + target_duration;
+
+        // Relying on `timeBeginPeriod`, this is the shortest amount of time we
+        // can reliably sleep.
+        let safe_sleep_duration = 2 * std::time::Duration::from_millis(self.min_period as u64);
+
+        // Let's sleep as long as possible within our safety margin.
+        if target_duration > safe_sleep_duration {
+            std::thread::sleep(target_duration - safe_sleep_duration);
+        }
+
+        // Busy wait the remaining time.
+        while std::time::Instant::now() < target_instant {}
+    }
+}
+
+#[cfg(windows)]
+impl LimiterImpl {
+    fn get_min_period() -> u32 {
+        use std::mem;
+        use winapi::um::{mmsystem::*, timeapi::timeGetDevCaps};
+
+        let mut time_caps = TIMECAPS {
+            wPeriodMin: 0,
+            wPeriodMax: 0,
+        };
+
+        unsafe {
+            let time_caps_size = mem::size_of::<TIMECAPS>() as u32;
+            if timeGetDevCaps(&mut time_caps as *mut TIMECAPS, time_caps_size) == TIMERR_NOERROR {
+                time_caps.wPeriodMin
+            } else {
+                1
+            }
+        }
+    }
+
+    fn init(&mut self) {
+        use winapi::um::timeapi::timeBeginPeriod;
+        println!("Setting min period to: {}", self.min_period);
+        unsafe {
+            timeBeginPeriod(self.min_period);
+        }
+    }
+
+    fn shutdown(&mut self) {
+        use winapi::um::timeapi::timeEndPeriod;
+        println!("Ending time period.");
+        unsafe {
+            timeEndPeriod(self.min_period);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+mod os_specific {}
+
+pub fn create() -> Box<dyn Limiter> {
+    Box::new(LimiterImpl::new())
+}

--- a/tester/src/main.rs
+++ b/tester/src/main.rs
@@ -11,10 +11,11 @@ fn main() {
     // run the thread limiter and then repeat.
     // NOTE: We want to keep the tests separate though as the current test is useful on it's own.
 
-    let limiters: [(&str, fn () -> Box<dyn Limiter>); 3] = [
+    let limiters: [(&str, fn () -> Box<dyn Limiter>); 4] = [
         ("Standard Sleep", limiter::standard_sleep::create),
         ("Time Period Standard Sleep", limiter::time_period_standard_sleep::create),
-        ("Time Period With Half Targets", limiter::time_period_close_sleep::create)
+        ("Time Period With Half Targets", limiter::time_period_close_sleep::create),
+        ("Time Period With Single Sleep", limiter::time_period_close_sleep_once::create),
     ];
 
     // General test calcs.


### PR DESCRIPTION
I've added a very naïve limiter as described in that issue. Here is the output on my main system:

```
Total loops: 500 at delta: 10
Limiter: Standard Sleep - total time: 5201ms (s: 5.2017862) - avg: 10ms - min: 10ms - max: 10ms
Setting min period to: 1
Limiter: Time Period Standard Sleep - total time: 5204ms (s: 5.2040197) - avg: 10ms - min: 10ms - max: 10ms
Ending time period.
Setting min period to: 1
Limiter: Time Period With Half Targets - total time: 4969ms (s: 4.9691288) - avg: 9.562ms - min: 9ms - max: 10ms
Ending time period.
Setting min period to: 1
Limiter: Time Period With Single Sleep - total time: 4999ms (s: 4.9994546) - avg: 9.006ms - min: 9ms - max: 10ms
Ending time period.
```

Intel Core i9-9900K
Windows 10 1909 (OS Build 18363.1139)